### PR TITLE
Using <gazebo_ros> to export model paths in package.xml

### DIFF
--- a/uav_simulator/package.xml
+++ b/uav_simulator/package.xml
@@ -32,6 +32,8 @@
   <exec_depend>gazebo_ros</exec_depend>
 
   <export>
-
+    <gazebo_ros gazebo_model_path="${prefix}/models"/>
+    <gazebo_ros gazebo_media_path="${prefix}"/>
+    <gazebo_ros plugin_path="${prefix}/plugins"/>
   </export>
 </package>


### PR DESCRIPTION
fix: https://github.com/Zhefan-Xu/Intent-MPC/issues/4
fix: https://github.com/Zhefan-Xu/Intent-MPC/issues/5
reference: https://docs.ros.org/en/iron/p/ros_gz_sim/standard_docs/README.html#using-gazebo-ros-to-export-model-paths-in-package-xml