### PR TITLE
Using <gazebo_ros> to export model paths in package.xml

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,6 @@ git clone https://github.com/Zhefan-Xu/Intent-MPC.git
 # step 3: follow the standard catkin_make procedure
 cd ~/catkin_ws
 catkin_make
-
-# step 4: add environment variables to your ~/.bashrc
-echo 'source path/to/uav_simulator/gazeboSetup.bash' >> ~/.bashrc
 ```
 
 

--- a/uav_simulator/gazeboSetup.bash
+++ b/uav_simulator/gazeboSetup.bash
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-export GAZEBO_MODEL_PATH=$GAZEBO_MODEL_PATH:${dir}/models
-export GAZEBO_RESOURCE_PATH=$GAZEBO_RESOURCE_PATH:${dir}/urdf
-export GAZEBO_PLUGIN_PATH=$GAZEBO_PLUGIN_PATH:${dir}/plugins

--- a/uav_simulator/package.xml
+++ b/uav_simulator/package.xml
@@ -32,6 +32,8 @@
   <exec_depend>gazebo_ros</exec_depend>
 
   <export>
-
+    <gazebo_ros gazebo_model_path="${prefix}/models"/>
+    <gazebo_ros gazebo_media_path="${prefix}"/>
+    <gazebo_ros plugin_path="${prefix}/plugins"/>
   </export>
 </package>


### PR DESCRIPTION
fix issue: https://github.com/Zhefan-Xu/Intent-MPC/issues/4 & https://github.com/Zhefan-Xu/Intent-MPC/issues/5
reference: [using-gazebo-ros-to-export-model-paths-in-package-xml](https://docs.ros.org/en/iron/p/ros_gz_sim/standard_docs/README.html#using-gazebo-ros-to-export-model-paths-in-package-xml)